### PR TITLE
Trim line to removing any trailing spaces

### DIFF
--- a/QifApi/QifDocument.cs
+++ b/QifApi/QifDocument.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using Hazzik.Qif.Parsers;
+﻿using Hazzik.Qif.Parsers;
 using Hazzik.Qif.Transactions;
 using Hazzik.Qif.Transactions.Fields;
 using Hazzik.Qif.Writers;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 
 namespace Hazzik.Qif
 {
@@ -144,6 +144,7 @@ namespace Hazzik.Qif
             IParser parser = null;
             while ((line = reader.ReadLine()) != null)
             {
+                line = line.Trim();
                 switch (line[0])
                 {
                     case InformationFields.TransactionType:
@@ -167,7 +168,7 @@ namespace Hazzik.Qif
         {
             switch (line)
             {
-                case Headers.Bank  :
+                case Headers.Bank:
                     return new BankParser();
                 case Headers.Cash:
                     return new CashParser();


### PR DESCRIPTION
When my quicken exports some accounts, it includes a trailing space at the end of the header like "!Type:Bank " (note space after 'k').  This causes a NotSupportedException to be thrown even though the file is otherwise valid.  I don't know how common this situation is, but this pull request simply trims the line read from the qif file.  This change is only made in the sync method, not the async version since that one is autogenerated.